### PR TITLE
runOnSave applies only to shellscript files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,11 +37,20 @@ export function activate(context: vscode.ExtensionContext) {
     if ('runOnSave' in settings && settings['runOnSave']) {
         vscode.workspace.onWillSaveTextDocument((event: vscode.TextDocumentWillSaveEvent) => {
             // Only on explicit save
-            if (event.reason === 1) {
+            if (event.reason === 1 && isAllowedTextDocument(event.document)) {
                 vscode.commands.executeCommand('shell.format.shfmt');
             }
         });
     }
+}
+
+function isAllowedTextDocument(textDocument: vscode.TextDocument): boolean {
+	if (textDocument.languageId !== 'shellscript') {
+		return false;
+	}
+
+	const scheme = textDocument.uri.scheme;
+	return (scheme === 'file' || scheme === 'untitled');
 }
 
 export function deactivate() {


### PR DESCRIPTION
This pull request would resolve issue #18.

Currently, the runOnSave feature executes whenever any file is saved. This pull request adds a condition to the runOnSave feature so that it executes only when a shellscript file is saved.

For reference, I copied and pasted it from another shellscript extension:
[https://github.com/timonwong/vscode-shellcheck/blob/master/src/linter.ts#L208](https://github.com/timonwong/vscode-shellcheck/blob/master/src/linter.ts#L208)

Please let me know if I missed anything or if it does not match this extension's code conventions.