### PR TITLE
Remove zsh and fish keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
         "properties",
         "formatter",
         "beautify",
-        "zsh",
-        "fish",
         "dotenv",
         "hosts",
         "jvmoptions",


### PR DESCRIPTION
As per https://github.com/mvdan/sh/issues/120 shfmt does **not** support zsh or fish files