### PR TITLE
Use https for URL in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Change Log
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file.
+
 ## [4.0.8] 2019-04-30
+
 - add github auto release
+
 ## [4.0.7] 2019-04-30
+
 - add azure pipelines for auto deploy
+
 ## [4.0.6] 2019-04-30
+
 - temporary disable linux auto download shfmt for ubuntu
+
 ## [4.0.5] 2019-04-09
+
 - fix always auto downoad
 
 ## [4.0.4] 2019-01-17


### PR DESCRIPTION
This should allow the changelog to be available via the extension
marketplace, as it requires all URLs to be https.