### PR TITLE
don't download shfmt if shellformat.path is specified

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -5,6 +5,8 @@ import { config } from "./config";
 import * as vscode from "vscode";
 import * as path from "path";
 import * as child_process from "child_process";
+import { getSettings } from "./shFormat"
+
 const MaxRedirects = 10;
 export interface DownloadProgress {
   (progress: number): void;
@@ -167,7 +169,8 @@ export function getReleaseDownloadUrl() {
 }
 
 export function getDestPath(context: vscode.ExtensionContext): string {
-  return path.join(context.extensionPath, "bin", getPlatFormFilename());
+  let shfmtPath: string = getSettings("path");
+  return shfmtPath || path.join(context.extensionPath, "bin", getPlatFormFilename());
 }
 
 async function ensureDirectory(dir: string) {
@@ -272,7 +275,7 @@ async function checkNeedInstall(
     }
     return needInstall;
   } catch (err) {
-    output.appendLine(`shfmt hasn't downloaded yet!`);
+    output.appendLine(`shfmt hasn't downloaded yet!` + err);
     output.show();
     return true;
   }

--- a/src/shFormat.ts
+++ b/src/shFormat.ts
@@ -374,3 +374,8 @@ function getDownloadUrl(): String {
 function isExecutedFmtCommand(): Boolean {
   return getExecutableFileUnderPath(Formatter.formatCommand) != null;
 }
+
+export function getSettings(key: string) {
+    let settings = vscode.workspace.getConfiguration(configurationPrefix);
+    return key !== undefined ? settings[key] : null;
+}

--- a/test/shfmt.test.ts
+++ b/test/shfmt.test.ts
@@ -1,0 +1,13 @@
+import { getSettings } from '../src/shFormat'
+import * as assert from 'assert'
+import { fileExists } from '../src/pathUtil';
+
+suite("shfmt path Tests", () => {
+
+    let shfmtPath = getSettings("path");
+
+    // Defines a Mocha unit test
+    test("shfmt exists", () => {
+        assert.equal(fileExists(shfmtPath), true);
+    });
+});


### PR DESCRIPTION
Don't download `shfmt` binary if user have set `shellformat.path`.