### PR TITLE
Add initial EditorConfig support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,8 +535,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -1277,6 +1276,38 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "elliptic": {
@@ -3874,6 +3905,11 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -3994,8 +4030,7 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
           "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4166,8 +4201,7 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -4249,6 +4283,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -194,21 +194,20 @@
     "format-check": "prettier --check './**/*.{js,jsx,ts,tsx,json,css,scss,md,yml,yaml,html}'"
   },
   "devDependencies": {
-
     "@types/mocha": "8.0.3",
     "@types/node": "10.17.28",
     "husky": "4.3.0",
     "lint-staged": "10.4.0",
     "prettier": "2.1.2",
     "mocha": "8.1.3",
-    "ts-loader": "7.0.5",
-    "typescript": "4.0.3",
     "ts-loader": "8.0.4",
+    "typescript": "4.0.3",
     "vscode": "1.1.37",
     "webpack": "4.44.1",
     "webpack-cli": "3.3.12"
   },
   "dependencies": {
-    "diff": "~4.0.0"
+    "diff": "~4.0.0",
+    "editorconfig": "^0.15.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -174,6 +174,11 @@
             "azcli"
           ],
           "description": "the trigger effect  on the language"
+        },
+        "shellformat.useEditorConfig": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use EditorConfig for shfmt configuration"
         }
       }
     }

--- a/src/shFormat.ts
+++ b/src/shFormat.ts
@@ -27,6 +27,7 @@ export enum ConfigItemName {
   Path = 'path',
   EffectLanguages = 'effectLanguages',
   ShowError = 'showError',
+  UseEditorConfig = 'useEditorConfig',
 }
 
 const defaultDownloadDirParrent = '/usr/local';
@@ -74,8 +75,17 @@ export class Formatter {
         let formatFlags = []; //todo add user configuration
         let settings = vscode.workspace.getConfiguration(configurationPrefix);
         let withFlagI = false;
+        let spawnOptions = {};
         if (settings) {
           let flag: string = settings['flag'];
+          let useEditorConfig: boolean = settings['useEditorConfig'];
+          if (useEditorConfig) {
+            spawnOptions['cwd'] = path.dirname(document.uri.fsPath);
+            withFlagI = true;
+            if (flag) {
+              flag = '';
+            }
+          }
           if (flag) {
             if (flag.includes('-w')) {
               vscode.window.showWarningMessage('can not set -w flag  please fix config');
@@ -111,7 +121,7 @@ export class Formatter {
         if (options && options.insertSpaces && !withFlagI) {
           formatFlags.push('-i', options.tabSize);
         }
-        let fmtSpawn = cp.spawn(Formatter.formatCommand, formatFlags);
+        let fmtSpawn = cp.spawn(Formatter.formatCommand, formatFlags, spawnOptions);
         let output: Buffer[] = [];
         let errorOutput: Buffer[] = [];
         let textEdits: TextEdit[] = [];


### PR DESCRIPTION
Projects may define _shfmt_ settings as part of an `.editorconfig` file. Where these settings are present we probably want to use them so shell formatting is consistent with the project settings.

This commit introduces a new setting to enable usage of settings defined in an `.editorconfig` file: `useEditorConfig` (_boolean_). The default is `false` to preserve existing behaviour.

Enabling this setting does three things:
1. Disables addition of any custom _shfmt_ flags defined in the `flag` setting. If any custom flags are provided to _shfmt_ it will ignore `.editorconfig` settings, making this setting mutually exclusive with the new setting.
2. Disables addition of the `-i` (indent) flag for the same reason as above.
3. Launches _shfmt_ in the directory of the file we're formatting. This ensures _shfmt_ is able to locate any `.editorconfig` file in the project (which may be further up the directory hierarchy).