### PR TITLE
fix: (issue#136) bump shfmt to 3.2.4, update enums

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 export const config = {
-  shfmtVersion: 'v3.1.1',
+  shfmtVersion: 'v3.2.4',
   needCheckInstall: true,
 };

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -79,7 +79,7 @@ export async function download2(
 
 enum Arch {
   arm = 'arm',
-  arm64 = 'arm',
+  arm64 = 'arm64',
   i386 = '386',
   mips = 'mips',
   x64 = 'amd64',
@@ -99,8 +99,9 @@ enum Platform {
 export function getArchExtension(): Arch {
   switch (process.arch) {
     case 'arm':
-    case 'arm64':
       return Arch.arm;
+    case 'arm64':
+      return Arch.arm64;
     case 'ia32':
     case 'x32':
       return Arch.i386;

--- a/src/shFormat.ts
+++ b/src/shFormat.ts
@@ -34,7 +34,7 @@ const defaultDownloadDir = '/usr/local/bin';
 const defaultDownloadShfmtPath = `${defaultDownloadDir}/shfmt`;
 const fileExtensionMap = {
   arm: 'arm',
-  arm64: 'arm',
+  arm64: 'arm64',
   ia32: '386',
   mips: 'mips',
   x32: '386',


### PR DESCRIPTION
Fix issue #136 

Update shfmtVersion to 3.2.4 in `config.ts`.

Update enums and case about "arm" and "arm64".

Now the target for auto downloading is match to [mvdan/sh:3.2.4](https://github.com/mvdan/sh/releases/tag/v3.2.4)