### PR TITLE
Fix: substitule `"${workspaceFolder}"` in need install check

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -235,7 +235,7 @@ async function cleanFile(file: string) {
 
 async function checkNeedInstall(dest: string, output: vscode.OutputChannel): Promise<boolean> {
   try {
-    const configPath = vscode.workspace.getConfiguration().get<string>(shellformatPath);
+    const configPath = getSettings('path');
     if (configPath) {
       try {
         await fs.promises.access(configPath, fs.constants.X_OK);

--- a/src/pathUtil.ts
+++ b/src/pathUtil.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as vscode from 'vscode';
 
 let binPathCache: { [bin: string]: string } = {};
 export function getExecutableFileUnderPath(toolName: string) {
@@ -36,4 +37,12 @@ export function fileExists(filePath: string): boolean {
   } catch (e) {
     return false;
   }
+}
+
+export function substitutePath(filePath: string): string {
+  let workspaceFolder =
+    vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.fsPath;
+  return filePath
+    .replace(/\${workspaceRoot}/g, workspaceFolder || '')
+    .replace(/\${workspaceFolder}/g, workspaceFolder || '');
 }

--- a/src/pathUtil.ts
+++ b/src/pathUtil.ts
@@ -8,6 +8,9 @@ export function getExecutableFileUnderPath(toolName: string) {
     return cachePath;
   }
   toolName = correctBinname(toolName);
+  if (path.isAbsolute(toolName)) {
+    return toolName;
+  }
   let paths = process.env['PATH'].split(path.delimiter);
   for (let i = 0; i < paths.length; i++) {
     let binpath = path.join(paths[i], toolName);
@@ -20,8 +23,11 @@ export function getExecutableFileUnderPath(toolName: string) {
 }
 
 function correctBinname(binname: string) {
-  if (process.platform === 'win32') return binname + '.exe';
-  else return binname;
+  if (process.platform === 'win32' && path.extname(binname) !== '.exe') {
+    return binname + '.exe';
+  } else {
+    return binname;
+  }
 }
 
 export function fileExists(filePath: string): boolean {

--- a/src/shFormat.ts
+++ b/src/shFormat.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
-import { fileExists, getExecutableFileUnderPath } from './pathUtil';
+import { fileExists, getExecutableFileUnderPath, substitutePath } from './pathUtil';
 import { output } from './extension';
 
 import { isDiffToolAvailable, getEdits, getEditsFromUnifiedDiffStr } from '../src/diffUtils';
@@ -391,9 +391,7 @@ function isExecutedFmtCommand(): Boolean {
 export function getSettings(key: string) {
   let settings = vscode.workspace.getConfiguration(configurationPrefix);
   if (key === 'path' && settings[key]) {
-    let workspaceFolder =
-      vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.fsPath;
-    return settings[key].replace(/\${workspaceFolder}/g, workspaceFolder || '');
+    return substitutePath(settings[key]);
   }
   return key !== undefined ? settings[key] : null;
 }


### PR DESCRIPTION
I have set `shellformat.path` with `${workspaceFolder}` in my settings since PR #228. However, after the extension has been loaded, the extension still downloads a `shfmt` program and replaces my executable, cause `checkNeedInstall` uses the raw path string from the settings.

The formatter works fine when I replace back my own `shfmt` executable. This PR fixes the extension replaces user's custom `shfmt` if the path contains `"${workspaceFolder}"`.