### PR TITLE
Edit package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shell-format",
   "displayName": "shell-format",
-  "description": "shellscript、Dockerfile、properties、gitignore、dotenv、hosts、jvmoptions... DocumentFormat",
+  "description": "A formatter for shell scripts, Dockerfile, gitignore, dotenv, /etc/hosts, jvmoptions, and other file types",
   "version": "7.2.2",
   "publisher": "foxundermoon",
   "engines": {


### PR DESCRIPTION
Fixes #211

Hi @foxundermoon, thanks very much for your work on this extension!

This PR is a small edit that fixes the comma character used in the package description.

You could also make the same change to the repo description on GitHub:

<table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/145714771-a932b177-2648-4fb1-9adc-28261d068dff.png" alt="image" /></td></tr></table>