### PR TITLE
Bug Fix: plugin will always crash since ini_one_bg.wasm is not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "dependencies": {
     "diff": "~5.1.0",
-    "editorconfig": "^2.0.0"
+    "editorconfig": "^0.15.3"
   },
   "licenses": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,11 +344,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@one-ini/wasm@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@one-ini/wasm/-/wasm-0.2.0.tgz#598671af52636ea6e0a849d026ad0e7c110e91cf"
-  integrity sha512-n+L/BvrwKUn7q5O3wHGo+CJZAqfewh38+37sk+eBzv/39lM9pPgPRd4sOZRvSRzo0ukLxzyXso4WlGj2oKZ5hA==
-
 "@secretlint/config-creator@^10.2.0":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@secretlint/config-creator/-/config-creator-10.2.0.tgz#5fdf29570e5cf1baa543677b3c2c8a9093105244"
@@ -2745,13 +2740,6 @@ mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
-minimatch@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
-  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimatch@3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Fix issue: https://github.com/foxundermoon/vs-shell-format/issues/396

I used your plugin and recommended it to others, but after the latest update, it's completely unusable. Others have the same issue, so I hope this can be fixed soon. I reviewed the recent changes and found that reverting the `editorconfig` version solves the problem. The fix is simple: just change the `editorconfig` dependency to the previous version, `7.2.5`.